### PR TITLE
fixed a bug to compute y vel

### DIFF
--- a/src/odometry.cpp
+++ b/src/odometry.cpp
@@ -85,7 +85,7 @@ bool Odometry::update(std::vector<double> omni_wheel_pos, const rclcpp::Time & t
 
   // Estimate speeds using a rolling mean to filter them out:
   linear_x_accumulator_.accumulate(lin_x / dt);
-  linear_y_accumulator_.accumulate(lin_x / dt);
+  linear_y_accumulator_.accumulate(lin_y / dt);
   angular_accumulator_.accumulate(angular / dt);
 
   lin_x_ = linear_x_accumulator_.getRollingMean();


### PR DESCRIPTION
hijimasa さん、はじめまして。

`omni_wheel_controller` を使ったところ、オドメトリトピックの `twist` の `linear` の `x` と `y` が同じ値になっていました。
原因調査のためにソースコードを見たところ、`linear_y_accumulator_` に `lin_x` が入力されてました。
この箇所を修正しました。
ご確認お願いします。