### PR TITLE
Updating from ROS2 Humble to ROS2 Jazzy.

### DIFF
--- a/src/omni_wheel_controller.cpp
+++ b/src/omni_wheel_controller.cpp
@@ -95,7 +95,7 @@ controller_interface::return_type OmniWheelController::update(
 {
 
   auto logger = get_node()->get_logger();
-  if (get_state().id() == State::PRIMARY_STATE_INACTIVE)
+  if (get_lifecycle_state().id() == State::PRIMARY_STATE_INACTIVE)
   {
     if (!is_halted)
     {

--- a/test/test_load_omni_wheel_controller.cpp
+++ b/test/test_load_omni_wheel_controller.cpp
@@ -16,6 +16,7 @@
 #include <memory>
 
 #include "controller_manager/controller_manager.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
 #include "rclcpp/utilities.hpp"
 //#include "ros2_control_test_assets/descriptions.hpp"
 #include "descriptions.hpp"
@@ -28,8 +29,7 @@ TEST(TestLoadOmniWheelController, load_controller)
     std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
 
   controller_manager::ControllerManager cm(
-    std::make_unique<hardware_interface::ResourceManager>(ros2_control_test_assets::omni_wheel_robot_urdf),
-    executor, "test_controller_manager");
+    executor, ros2_control_test_assets::omni_wheel_robot_urdf, true, "test_controller_manager");
 
   ASSERT_NE(
     cm.load_controller("test_omni_wheel_controller", "omni_wheel_controller/OmniWheelController"),

--- a/test/test_omni_wheel_controller.cpp
+++ b/test/test_omni_wheel_controller.cpp
@@ -185,11 +185,14 @@ protected:
 
   rclcpp::Node::SharedPtr pub_node;
   rclcpp::Publisher<geometry_msgs::msg::TwistStamped>::SharedPtr velocity_publisher;
+
+  const std::string urdf_ = "";
 };
 
 TEST_F(TestOmniWheelController, configure_fails_without_parameters)
 {
-  const auto ret = controller_->init(controller_name);
+  const auto ret =
+    controller_->init(controller_name, urdf_, 0, "", controller_->define_custom_node_options());
   ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   ASSERT_EQ(controller_->on_configure(rclcpp_lifecycle::State()), CallbackReturn::ERROR);
@@ -197,7 +200,8 @@ TEST_F(TestOmniWheelController, configure_fails_without_parameters)
 
 TEST_F(TestOmniWheelController, configure_succeeds_when_wheels_are_specified)
 {
-  const auto ret = controller_->init(controller_name);
+  const auto ret =
+    controller_->init(controller_name, urdf_, 0, "", controller_->define_custom_node_options());
   ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   controller_->get_node()->set_parameter(
@@ -215,7 +219,8 @@ TEST_F(TestOmniWheelController, configure_succeeds_when_wheels_are_specified)
 
 TEST_F(TestOmniWheelController, configure_succeeds_tf_test_prefix_false_no_namespace)
 {
-  const auto ret = controller_->init(controller_name);
+  const auto ret =
+    controller_->init(controller_name, urdf_, 0, "", controller_->define_custom_node_options());
   ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   std::string odom_id = "odom";
@@ -246,7 +251,8 @@ TEST_F(TestOmniWheelController, configure_succeeds_tf_test_prefix_false_no_names
 
 TEST_F(TestOmniWheelController, configure_succeeds_tf_test_prefix_true_no_namespace)
 {
-  const auto ret = controller_->init(controller_name);
+  const auto ret =
+    controller_->init(controller_name, urdf_, 0, "", controller_->define_custom_node_options());
   ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   std::string odom_id = "odom";
@@ -279,7 +285,8 @@ TEST_F(TestOmniWheelController, configure_succeeds_tf_test_prefix_true_no_namesp
 
 TEST_F(TestOmniWheelController, configure_succeeds_tf_blank_prefix_true_no_namespace)
 {
-  const auto ret = controller_->init(controller_name);
+  const auto ret =
+    controller_->init(controller_name, urdf_, 0, "", controller_->define_custom_node_options());
   ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   std::string odom_id = "odom";
@@ -313,7 +320,8 @@ TEST_F(TestOmniWheelController, configure_succeeds_tf_test_prefix_false_set_name
 {
   std::string test_namespace = "/test_namespace";
 
-  const auto ret = controller_->init(controller_name, test_namespace);
+  const auto ret =
+    controller_->init(controller_name, urdf_, 0, "", controller_->define_custom_node_options());
   ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   std::string odom_id = "odom";
@@ -346,7 +354,8 @@ TEST_F(TestOmniWheelController, configure_succeeds_tf_test_prefix_true_set_names
 {
   std::string test_namespace = "/test_namespace";
 
-  const auto ret = controller_->init(controller_name, test_namespace);
+  const auto ret =
+    controller_->init(controller_name, urdf_, 0, "", controller_->define_custom_node_options());
   ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   std::string odom_id = "odom";
@@ -381,7 +390,8 @@ TEST_F(TestOmniWheelController, configure_succeeds_tf_blank_prefix_true_set_name
 {
   std::string test_namespace = "/test_namespace";
 
-  const auto ret = controller_->init(controller_name, test_namespace);
+  const auto ret =
+    controller_->init(controller_name, urdf_, 0, "", controller_->define_custom_node_options());
   ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   std::string odom_id = "odom";
@@ -413,7 +423,8 @@ TEST_F(TestOmniWheelController, configure_succeeds_tf_blank_prefix_true_set_name
 
 TEST_F(TestOmniWheelController, activate_fails_without_resources_assigned)
 {
-  const auto ret = controller_->init(controller_name);
+  const auto ret =
+    controller_->init(controller_name, urdf_, 0, "", controller_->define_custom_node_options());
   ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   controller_->get_node()->set_parameter(
@@ -425,7 +436,8 @@ TEST_F(TestOmniWheelController, activate_fails_without_resources_assigned)
 
 TEST_F(TestOmniWheelController, activate_succeeds_with_pos_resources_assigned)
 {
-  const auto ret = controller_->init(controller_name);
+  const auto ret =
+    controller_->init(controller_name, urdf_, 0, "", controller_->define_custom_node_options());
   ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   // We implicitly test that by default position feedback is required
@@ -439,7 +451,8 @@ TEST_F(TestOmniWheelController, activate_succeeds_with_pos_resources_assigned)
 
 TEST_F(TestOmniWheelController, cleanup)
 {
-  const auto ret = controller_->init(controller_name);
+  const auto ret =
+    controller_->init(controller_name, urdf_, 0, "", controller_->define_custom_node_options());
   ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   controller_->get_node()->set_parameter(
@@ -490,7 +503,8 @@ TEST_F(TestOmniWheelController, cleanup)
 
 TEST_F(TestOmniWheelController, correct_initialization_using_parameters)
 {
-  const auto ret = controller_->init(controller_name);
+  const auto ret =
+    controller_->init(controller_name, urdf_, 0, "", controller_->define_custom_node_options());
   ASSERT_EQ(ret, controller_interface::return_type::OK);
 
   controller_->get_node()->set_parameter(


### PR DESCRIPTION

The commit has only one small change in omni_wheel_controller.cpp. The bulk of the changes relate to test. These changes in this pull request should be sufficient to build the omniwheel controller on Jazzy.

To actually use the controller on a real robot I found the robot_hardware_description.urdf now needs to explicitly define joint names outside the hardware tag. Also for a launch file the ros2 control node no longer accepts robot description content. This must be passed using a robot state publisher.

I have a demonstration robot and you may wish to look at the following files specifically to see how this now works in Jazzy:
https://github.com/jfrancis71/ros2_holonomic_lego/blob/main/terry/config/robot_hardware_description.urdf
https://github.com/jfrancis71/ros2_holonomic_lego/blob/main/terry/launch/brickpi3_motors_launch.py



ROS2 relevant changes:

See: https://github.com/ros-controls/ros2_control/pull/1683 for change to src/omni_wheel_controller.cpp

See https://github.com/ros-controls/ros2_controllers/commit/8bf379b2726900adec452193a777d900ba152e89 and also commit https://github.com/ros-controls/ros2_controllers/commit/991ef48b79a12974a1b37763e818842906e3553b for change to test/test_load_omni_wheel_controller.cpp

See https://github.com/ros-controls/ros2_controllers/commit/2817f2779673e43d1c63ee0d8b35c8ed6f85410d for change to test/test_omni_wheel_controller.cpp
